### PR TITLE
Yum remove list instead of loop

### DIFF
--- a/setupiPXEServer/tasks/destroyMainGuy.yml
+++ b/setupiPXEServer/tasks/destroyMainGuy.yml
@@ -16,12 +16,11 @@
 
   - name: Erase DHCP Package
     yum:
-      name: '{{ item }}'
+      name: 
+        - dhcp-compat
+        - dhcp-relay
+        - dhcp-server
       state: absent
-    loop:
-      - dhcp-compat
-      - dhcp-relay
-      - dhcp-server
 
   - name: Delete Default DHCP Directory
     file:


### PR DESCRIPTION
When using the yum module to remove or install packages, it is preferable to use a list for a single yum command, instead of one iteration of yum for each item in the loop.